### PR TITLE
Feature/gihub issue 26 add include isoform

### DIFF
--- a/test/test_dataset/test_request.py
+++ b/test/test_dataset/test_request.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+import pytest
+
 from unipressed import *
 from unipressed.dataset.search import Search
 
@@ -203,3 +205,17 @@ def test_arba():
             query={"and_": [{"taxonomy": "chloroflexi"}, {"keyword": "metal-binding"}]}
         )
     )
+
+@pytest.mark.paremetrize("include_isoform,expected_result_count", [(True, 2), (False, 1)])
+def test_UnirefClient_search_include_isoform(include_isoform: bool, expected_result_count: int):
+    records = list(
+        UniprotkbClient.search(
+            query={
+                "accession": "Q8WU66",
+                "organism_id": "9606",
+            },
+            fields=["date_created", "protein_name"],
+            include_isoform=include_isoform,
+        ).each_record()
+    )
+    assert len(records) == expected_result_count

--- a/test/test_dataset/test_request.py
+++ b/test/test_dataset/test_request.py
@@ -206,8 +206,13 @@ def test_arba():
         )
     )
 
-@pytest.mark.paremetrize("include_isoform,expected_result_count", [(True, 2), (False, 1)])
-def test_UnirefClient_search_include_isoform(include_isoform: bool, expected_result_count: int):
+
+@pytest.mark.parametrize(
+    "include_isoform,expected_result_count", [(True, 2), (False, 1)]
+)
+def test_UnirefClient_search_include_isoform(
+    include_isoform: bool, expected_result_count: int
+):
     records = list(
         UniprotkbClient.search(
             query={

--- a/unipressed/dataset/core.py
+++ b/unipressed/dataset/core.py
@@ -51,7 +51,12 @@ class DatasetClient(
         Refer to the [unipressed.dataset.search.Search][] reference for more information on how to use it.
         """
         return Search[QueryType, JsonResultType, FieldsType, FormatType](
-            query=query, format=format, dataset=cls.name(), fields=fields, size=size, include_isoform=include_isoform
+            query=query,
+            format=format,
+            dataset=cls.name(),
+            fields=fields,
+            size=size,
+            include_isoform=include_isoform,
         )
 
     @overload

--- a/unipressed/dataset/core.py
+++ b/unipressed/dataset/core.py
@@ -44,13 +44,14 @@ class DatasetClient(
         format: FormatType | Literal["json"] = "json",
         fields: Iterable[FieldsType] | None = None,
         size: int = 500,
+        include_isoform: bool = True,
     ) -> Search[QueryType, JsonResultType, FieldsType, FormatType]:
         """
         Creates an object that can be used to perform a search query over this dataset.
         Refer to the [unipressed.dataset.search.Search][] reference for more information on how to use it.
         """
         return Search[QueryType, JsonResultType, FieldsType, FormatType](
-            query=query, format=format, dataset=cls.name(), fields=fields, size=size
+            query=query, format=format, dataset=cls.name(), fields=fields, size=size, include_isoform=include_isoform
         )
 
     @overload


### PR DESCRIPTION
This PR surfaces the `include_isoform` parameter to the `UniprotkbClient` class as described in the GitHub Issue 26:
https://github.com/multimeric/Unipressed/issues/26