### PR TITLE
Adds OpenTargets as From/To database

### DIFF
--- a/unipressed/id_mapping/types.py
+++ b/unipressed/id_mapping/types.py
@@ -67,6 +67,7 @@ From: TypeAlias = Literal[
     "MGI",
     "MIM",
     "neXtProt",
+    "OpenTargets",
     "Orphanet",
     "PharmGKB",
     "PomBase",
@@ -167,6 +168,7 @@ To: TypeAlias = Literal[
     "MGI",
     "MIM",
     "neXtProt",
+    "OpenTargets",
     "Orphanet",
     "PharmGKB",
     "PomBase",
@@ -199,3 +201,4 @@ To: TypeAlias = Literal[
     "DisProt",
     "IDEAL",
 ]
+

--- a/unipressed/id_mapping/types.py
+++ b/unipressed/id_mapping/types.py
@@ -201,4 +201,3 @@ To: TypeAlias = Literal[
     "DisProt",
     "IDEAL",
 ]
-


### PR DESCRIPTION
The OpenTargets is now available and listed in the valid databases list (https://rest.uniprot.org/configure/idmapping/fields).