### PR TITLE
fix(id_mapping): fix typo taxId -> taxid

### DIFF
--- a/test/test_id_mapping/test_id_mapping.py
+++ b/test/test_id_mapping/test_id_mapping.py
@@ -184,3 +184,13 @@ def test_taxon_id_all():
     assert "P0CI39" in results
     # Mouse gene
     assert "P14719" in results
+
+def test_taxon_id_different_database():
+    # Checks that the taxId parameter works in different databases (P38398 comes from human BRCA1)
+    request = IdMappingClient.submit(
+        source="UniProtKB_AC-ID", dest="Ensembl_Protein", ids={"P38398"}, taxon_id=9606
+    )
+    sleep(5)
+    results = {result["to"] for result in request.each_result()}
+    assert len(results) >= 1
+    assert "ENSP00000312236.5" in results

--- a/unipressed/id_mapping/core.py
+++ b/unipressed/id_mapping/core.py
@@ -52,7 +52,7 @@ class IdMappingClient:
     ) -> requests.Response:
         data: dict[str, Any] = {"ids": ",".join(ids), "from": source, "to": dest}
         if taxon_id is not None:
-            data["taxId"] = taxon_id
+            data["taxid"] = taxon_id
         return requests.post(
             "https://rest.uniprot.org/idmapping/run",
             data=data,


### PR DESCRIPTION
As described in title. This is the error I get directly from the request instance (without my change):
```
400 {"url":"http://rest.uniprot.org/idmapping/run","messages":["Invalid parameter 'taxId'"]}
```

Steps to reproduce the problem (P38398 comes from human BRCA1):
```python
request = IdMappingClient.submit(
        taxon_id=9606, source="UniProtKB_AC-ID", dest="Ensembl_Protein", ids=['P38398']
)
```